### PR TITLE
Proper JSON output and input file override

### DIFF
--- a/clinvar_report.py
+++ b/clinvar_report.py
@@ -34,12 +34,16 @@ def json_report(input_genome_file, input_clinvar_file, build, notes, version):
             data = {
                 'chrom': genome_vcf_line.chrom,
                 'pos': genome_vcf_line.start,
-                'ref-allele': genome_vcf_line.ref_allele,
+                'ref_allele': genome_vcf_line.ref_allele,
                 # Note that var_allele CAN be the same as the ref_allele, if
                 # the reference variant is considered pathogenic! Factor V
                 # Leiden is a famous example.
-                'var-allele': clinvar_allele.sequence,
+                'alt_allele': clinvar_allele.sequence,
                 'zygosity': zygosity,
+                'name': record.dbn,
+                'acc_url': 'http://www.ncbi.nlm.nih.gov/clinvar/' + record.acc,
+                'allele_freq': clinvar_allele.frequency,
+                'clinical_significance': record.inf,
             }
             json_report['variants'].append(data)
     print(json.dumps(json_report))
@@ -114,9 +118,7 @@ def main():
 
     version = os.popen("python setup.py --version").read().strip()
 
-    if not sys.stdin.isatty():
-        input_genome_file = sys.stdin
-    elif options.inputfile:
+    if options.inputfile:
         if options.inputfile.endswith('.vcf'):
             input_genome_file = open(options.inputfile)
         elif options.inputfile.endswith('.vcf.gz'):
@@ -126,6 +128,8 @@ def main():
         else:
             raise IOError("Genome filename expected to end with ''.vcf'," +
                           " '.vcf.gz', or '.vcf.bz2'.")
+    elif not sys.stdin.isatty():
+        input_genome_file = sys.stdin
     else:
         sys.stderr.write("Provide input VCF file\n")
         parser.print_help()

--- a/vcf2clinvar/clinvar.py
+++ b/vcf2clinvar/clinvar.py
@@ -51,6 +51,7 @@ class ClinVarRecord(object):
         self.acc = clnacc
         self.dbn = clndbn
         self.sig = clnsig
+        self.inf = CLNSIG_INDEX[clnsig]
 
     def __unicode__(self):
         """Return ClinVarRecord data as JSON-formatted string."""


### PR DESCRIPTION
- The JSON being produced didn't have some fields and
  didn't have the 'inferred clinical significance', just
  the code.  The JSON now has the fields as specified
  in the `schema/genevieve-report-schema.json` file (with
  proper spelling).  The `inf` (for 'inferred') field was added to the ClinVarRecord
  for the string clinical significance.
- If an input VCF file was specified, the `isatty` code would
  take precedence instead of the specified input file (with the `-i` option).
  This has been changed so that if the input file is specified, it takes
  precedence and only if the input file isn't specified does
  it look for input from stdin.  I think this still works as expected in that
  if running from the command line with no inputs, it produces the help screen,
  running with an '-i' option will use the file specified and if no '-i' option
  is specified but a VCF is piped in, it will use it.  That is, the following works
  as expected:

```
$ ./clinvar_report.py -c <path/to/clinvar.vcf> -g b37
... shows help ...
$ ./clinvar_report.py -c <path/to/clinvar.vcf> -g b37 -i examples/abe.vcf
... gives CSV report for abe.vcf ...
$ cat examples/abe.vcf | ./clinvar_report.py -c <path/to/clinvar.vcf> -g b37
... gives CSV report for abe.vcf ...
$ cat file/to/be/ignored | ./clinvar_report.py -c <path/to/clinvar.vcf> -g b37 -i examples/abe.vcf
... gives CSV report for abe.vcf ...
```
